### PR TITLE
Improve public library interface

### DIFF
--- a/Sources/libMultiMarkdown/include/libMultiMarkdown.h
+++ b/Sources/libMultiMarkdown/include/libMultiMarkdown.h
@@ -121,6 +121,17 @@ bool mmd_string_has_metadata(const char * source, size_t* end);
 bool mmd_has_metadata(mmd_engine * e, size_t * end);
 
 
+// Extract metadata keys from string
+char * mmd_metadata_keys_string(const char * source, unsigned long extensions, short format, short language);
+
+
+// Extract metadata keys from DString
+char * mmd_metadata_keys(DString * source, unsigned long extensions, short format, short language);
+
+
+// Extract metadata keys from parsed engine
+char * mmd_metadata_keys_engine(mmd_engine* e);
+
 /// Extract desired metadata as string value
 char * metavalue_for_key(mmd_engine * e, const char * key);
 

--- a/Sources/libMultiMarkdown/include/libMultiMarkdown.h
+++ b/Sources/libMultiMarkdown/include/libMultiMarkdown.h
@@ -118,6 +118,9 @@ void mmd_engine_parse_string(mmd_engine * e);
 
 /// Does the text have metadata?
 bool mmd_string_has_metadata(const char * source, size_t* end);
+
+
+/// Does the text have metadata?
 bool mmd_has_metadata(mmd_engine * e, size_t * end);
 
 

--- a/Sources/libMultiMarkdown/include/libMultiMarkdown.h
+++ b/Sources/libMultiMarkdown/include/libMultiMarkdown.h
@@ -139,6 +139,10 @@ char * mmd_metadata_keys_engine(mmd_engine* e);
 char * metavalue_for_key(mmd_engine * e, const char * key);
 
 
+// Extract desired metadata as string value from string
+char * metavalue_from_string(const char * source, const char * key);
+
+
 void mmd_export_token_tree(DString * out, mmd_engine * e, short format);
 
 

--- a/Sources/libMultiMarkdown/include/libMultiMarkdown.h
+++ b/Sources/libMultiMarkdown/include/libMultiMarkdown.h
@@ -117,6 +117,7 @@ void mmd_engine_parse_string(mmd_engine * e);
 
 
 /// Does the text have metadata?
+bool mmd_string_has_metadata(const char * source, size_t* end);
 bool mmd_has_metadata(mmd_engine * e, size_t * end);
 
 

--- a/Sources/libMultiMarkdown/mmd.c
+++ b/Sources/libMultiMarkdown/mmd.c
@@ -2002,6 +2002,8 @@ char * metavalue_for_key(mmd_engine * e, const char * key) {
 char * mmd_convert_string(const char * source, unsigned long extensions, short format, short language) {
 	char * result;
 
+	token_pool_init();
+
 	mmd_engine * e = mmd_engine_create_with_string(source, extensions);
 
 	mmd_engine_set_language(e, language);
@@ -2016,6 +2018,8 @@ char * mmd_convert_string(const char * source, unsigned long extensions, short f
 
 	mmd_engine_free(e, true);			// The engine has a private copy of source that must be freed
 	d_string_free(output, false);
+
+	token_pool_drain();
 
 	return result;
 }

--- a/Sources/libMultiMarkdown/mmd.c
+++ b/Sources/libMultiMarkdown/mmd.c
@@ -1909,6 +1909,27 @@ void mmd_engine_parse_string(mmd_engine * e) {
 	e->root = mmd_engine_parse_substring(e, 0, e->dstr->currentStringLength);
 }
 
+bool mmd_string_has_metadata(const char * source, size_t* end) {
+		bool result;
+
+		token_pool_init();
+
+		mmd_engine * e = mmd_engine_create_with_string(source, EXT_SNIPPET);
+
+		mmd_engine_set_language(e, ENGLISH);
+
+		mmd_engine_parse_string(e);
+
+		mmd_engine_parse_string(e);
+
+		result = mmd_has_metadata(e, end);
+
+		mmd_engine_free(e, true);			// The engine has a private copy of source that must be freed
+
+		token_pool_drain();
+		
+		return result;
+}
 
 bool mmd_has_metadata(mmd_engine * e, size_t * end) {
 	bool result = false;

--- a/Sources/libMultiMarkdown/mmd.c
+++ b/Sources/libMultiMarkdown/mmd.c
@@ -1996,6 +1996,25 @@ char * metavalue_for_key(mmd_engine * e, const char * key) {
 	return result;
 }
 
+
+// Grab metadata without processing entire document
+// Returned char * does not need to be freed
+char * metavalue_from_string(const char * source, const char * key) {
+	char * result;
+
+	token_pool_init();
+
+	mmd_engine * e = mmd_engine_create_with_string(source, EXT_SNIPPET);
+
+	result = metavalue_for_key(e, key);
+
+	mmd_engine_free(e, true); // The engine has a private copy of source that must be freed
+
+	token_pool_drain();
+	return result;
+}
+
+
 // Extract Metadata keys from an engine, returning one key on each line
 // Returned char* must be freed
 char * mmd_metadata_keys_engine(mmd_engine* e) {


### PR DESCRIPTION
This PR makes two changes:
1. Adds the function `mmd_string_has_metadata`, which operates identically to `mmd_has_metadata`, but accepts a raw C-style string as opposed to an `mmd_engine` for usage from third party libraries.
2. Adds `token_pool_init()` and `token_pool_drain()` calls to `mmd_convert_string()` to ensure a token pool has been initialized for conversion. This isn't called currently, causing segmentation faults.