### PR TITLE
ADDED: External function for testing for metadata

### DIFF
--- a/Sources/libMultiMarkdown/include/libMultiMarkdown.h
+++ b/Sources/libMultiMarkdown/include/libMultiMarkdown.h
@@ -117,6 +117,10 @@ void mmd_engine_parse_string(mmd_engine * e);
 
 
 /// Does the text have metadata?
+bool mmd_string_has_metadata(const char * source, size_t* end);
+
+
+/// Does the text have metadata?
 bool mmd_has_metadata(mmd_engine * e, size_t * end);
 
 

--- a/Sources/libMultiMarkdown/mmd.c
+++ b/Sources/libMultiMarkdown/mmd.c
@@ -1909,6 +1909,27 @@ void mmd_engine_parse_string(mmd_engine * e) {
 	e->root = mmd_engine_parse_substring(e, 0, e->dstr->currentStringLength);
 }
 
+bool mmd_string_has_metadata(const char * source, size_t* end) {
+		bool result;
+
+		token_pool_init();
+
+		mmd_engine * e = mmd_engine_create_with_string(source, EXT_SNIPPET);
+
+		mmd_engine_set_language(e, ENGLISH);
+
+		mmd_engine_parse_string(e);
+
+		mmd_engine_parse_string(e);
+
+		result = mmd_has_metadata(e, end);
+
+		mmd_engine_free(e, true);			// The engine has a private copy of source that must be freed
+
+		token_pool_drain();
+		
+		return result;
+}
 
 bool mmd_has_metadata(mmd_engine * e, size_t * end) {
 	bool result = false;


### PR DESCRIPTION
Adds function which can test for existence of metadata from a C-style string, useful for using MMD6 from an external interface.