### PR TITLE
FIXED: Initialize and drain token pool in convenience mmd_convert_string

### DIFF
--- a/Sources/libMultiMarkdown/mmd.c
+++ b/Sources/libMultiMarkdown/mmd.c
@@ -1981,6 +1981,8 @@ char * metavalue_for_key(mmd_engine * e, const char * key) {
 char * mmd_convert_string(const char * source, unsigned long extensions, short format, short language) {
 	char * result;
 
+	token_pool_init();
+
 	mmd_engine * e = mmd_engine_create_with_string(source, extensions);
 
 	mmd_engine_set_language(e, language);
@@ -1995,6 +1997,8 @@ char * mmd_convert_string(const char * source, unsigned long extensions, short f
 
 	mmd_engine_free(e, true);			// The engine has a private copy of source that must be freed
 	d_string_free(output, false);
+
+	token_pool_drain();
 
 	return result;
 }


### PR DESCRIPTION
When using this call as a public interface for converting strings, these calls are required, but are internal details. This maintains the encapsulation by calling these functions before and after engine creation/teardown.