### PR TITLE
fix Mac target platform recognition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ MACRO(ADD_PUBLIC_HEADER target filename)
 	
 	SET_TARGET_PROPERTIES(${target} PROPERTIES
 		XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS
-		"macos iphonesimulator iphoneos"
+		"macosx iphonesimulator iphoneos"
 	)
 
 	SET_TARGET_PROPERTIES(${target} PROPERTIES


### PR DESCRIPTION
This makes Xcode 9 recognize Mac as a build target platform.

(Sorry, forked from `master` again instead of develop.)