### PR TITLE
Cocoa enum conversion script

### DIFF
--- a/swift/cocoaconv.rb
+++ b/swift/cocoaconv.rb
@@ -93,27 +93,33 @@ class String
 end
 
 module NSEnum
-  def self.type_names(type)
+  def self.type_name(type)
     type_name = type.camelize
     # Remove plural "S"
-    type_name = if type_name == "TokenTypes"
-                  "TokenType"
-                elsif type_name == "ParserExtensions"
-                  "ParserExtension"
-                else
-                  type_name
-                end
-    return "MMD6#{type_name}", type_name
+    if type_name == "TokenTypes"
+      "TokenType"
+    elsif type_name == "ParserExtensions"
+      "ParserExtension"
+    else
+      type_name
+    end
+  end
+  
+  def type_name
+    NSEnum.type_name(type)
   end
 
   def ns_enum
-    type_name, swift_type_name = NSEnum.type_names(type)
+    base_type_name = NSEnum.type_name(type)
+    swift_type_name = base_type_name
+    objc_type_name = "MMD6#{base_type_name}"
+    
     ns_enum_cases = cases
-      .map { |line| NSEnum.case(type_name, line) }
+      .map { |line| NSEnum.case(objc_type_name, line) }
       .join("\n")
       
     return %Q{
-typedef NS_ENUM(NSUInteger, #{type_name}) {
+typedef NS_ENUM(NSUInteger, #{objc_type_name}) {
 #{ns_enum_cases}
 } NS_SWIFT_NAME(#{swift_type_name});}
   end

--- a/swift/cocoaconv.rb
+++ b/swift/cocoaconv.rb
@@ -126,8 +126,19 @@ typedef NS_ENUM(NSUInteger, #{objc_type_name}) {
 
   def self.case(type_name, line)
     if /(?<indent>\s*)(?<casename>\w+)(?<remainder>.*)/ =~ line
-      return %Q{#{indent}#{type_name}#{casename.camelize} = #{casename},}
+      # Drop redundant enum base prefixes:
+      # "MMD6OutputFormatFormatLatex"  => "MMD6OutputFormatLatex"
+      # "MMD6ParserExtensionExtCritic" => "MMD6ParserExtensionCritic"
+      camelized_case_name = if casename.start_with?("EXT_")
+                              casename[4..-1].camelize
+                            elsif casename.start_with?("FORMAT_")
+                              casename[7..-1].camelize
+                            else 
+                              casename.camelize
+                            end
+      return %Q{#{indent}#{type_name}#{camelized_case_name} = #{casename},}
     end
+    
     return line
   end
 end

--- a/swift/cocoaconv.rb
+++ b/swift/cocoaconv.rb
@@ -1,0 +1,229 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+CURRENT_PATH = File.expand_path(File.dirname(__FILE__))
+FALLBACK_PATH = File.join(CURRENT_PATH, "..", "build-xcode", "Debug", "include", "libMultiMarkdown", "libMultiMarkdown.h")
+
+options = {:mode => :nsenum}
+OptionParser.new do |parser|
+  parser.banner = "Usage: #{$0} [options] path/to/libMultiMarkdown.h"
+  
+  parser.separator ""
+  parser.separator "Without an input path, the script uses this default relative project location:"
+  parser.separator "../build-xcode/Debug/include/libMultiMarkdown/libMultiMarkdown.h"
+  parser.separator ""
+    
+  parser.on("-h", "--help", "Prints this help") do
+    puts parser
+    exit
+  end
+  
+  parser.on("-m", "--mode [MODE]", [:swift, :nsenum],
+          "Select generator:",
+          "  nsenum    Generates Objective-C NS_ENUM wrappers. (Default)",
+          "  swift     Generates Swift enum descriptions.") do |mode|
+    options[:mode] = mode
+  end
+  
+  parser.on("-o", "--output [PATH]", String,
+            "Write output to file instead of STDOUT. (Optional)") do |path|
+    options[:outpath] = path
+  end
+end.parse!
+
+
+################################################################################
+## Types to perform the conversion
+################################################################################
+
+
+module CustomStringConvertible  
+  def extension
+    indentation = "            "
+    cases = case_descriptions
+      .map { |line| indentation + line }
+      .join("\n")
+
+    return %Q{
+extension #{type_name}: CustomStringConvertible {
+    public var description: String {
+        switch self {
+#{cases}
+        }
+    }
+}}
+  end
+
+  private 
+  
+  def case_descriptions
+    cases.map { |c| CustomStringConvertible.description_for(self.type_name, c) }
+  end
+  
+  def indented_case_descriptions(indent)
+    case_descriptions
+      .map { |line| indent + line }
+      .join("\n")
+  end
+  
+  def self.description_for(type_name, enum_case)
+    case_name = case_only(enum_case)
+    swift_case_name = case_name.camelize(lowercase_first: true)
+    %Q{case .#{swift_case_name}: return "#{type_name}.#{swift_case_name}"}
+  end
+  
+  def self.case_only(line)
+    line[/\w+/]
+  end
+end
+
+class String
+  def camelize(lowercase_first: false)
+    self
+      .split('_')
+      .map.with_index { |part, i| 
+        if lowercase_first && i == 0
+          part.downcase
+        else
+          part.capitalize
+        end }
+      .join
+  end
+end
+
+module NSEnum
+  def type_name
+    type.camelize
+  end
+  
+  def self.type_names(type)
+    return "MMD6#{type.camelize}", type.camelize
+  end
+
+  def ns_enum
+    type_name, swift_type_name = NSEnum.type_names(type)
+    ns_enum_cases = cases
+      .map { |line| NSEnum.case(type_name, line) }
+      .join("\n")
+      
+    %Q{typedef NS_ENUM(NSUInteger, #{type_name}) {
+#{ns_enum_cases}
+} NS_SWIFT_NAME(#{swift_type_name});}
+  end
+
+  def self.case(type_name, line)
+    if /(?<indent>\s*)(?<casename>\w+)(?<remainder>.*)/ =~ line
+      return %Q{#{indent}#{type_name}#{casename.camelize} = #{casename},}
+    end
+    return line
+  end
+end
+
+class Enum
+  include CustomStringConvertible
+  include NSEnum
+  
+  attr_accessor :type, :cases
+  
+  def initialize(type)
+    @type = type
+    @cases = []
+  end
+  
+  def <<(line)
+    return if !Enum.is_enum_case(line)
+    cases << line
+  end
+  
+  def self.is_enum_case(line)
+    return false if line.strip.empty?
+    return false if line.include?("}")
+    return false if line.include?("{")
+    return true
+  end
+end
+
+class Enums
+  attr_reader :enums
+  
+  def initialize(stream)
+    lines = stream.readlines
+    @enums = parse_enums(lines)
+  end
+  
+  def ns_enums
+    @enums.map(&:ns_enum)
+  end
+  
+  def swift_descriptions
+    @enums.map(&:extension)
+  end
+  
+  private 
+
+  def parse_enums(lines)
+    enums = []
+    enumbuffer = nil
+    lines.each do |line|
+      type = line[/^\s*enum (\w+)\s*\{/, 1]
+      if !type.nil?
+        enumbuffer = Enum.new(type)
+      elsif !enumbuffer.nil?
+        if line.start_with?("}")
+          enums << enumbuffer
+          enumbuffer = nil
+        else
+          enumbuffer << line
+        end
+      else
+        # nop; discard line
+      end
+    end
+    return enums
+  end
+end
+
+def file_stream_from_argv
+  path = ARGV.shift
+  return nil if path.nil?
+  File.open(path, "r")
+end
+
+def fallback_stream
+  return nil unless File.exists?(FALLBACK_PATH)
+  File.open(FALLBACK_PATH, "r")
+end
+
+
+################################################################################
+## Script execution itself
+################################################################################
+
+
+input  = file_stream_from_argv || fallback_stream
+if input.nil?
+  puts "Failed to read `#{FALLBACK_PATH}`"
+  exit -1
+end
+enums = Enums.new(input)
+input.close
+
+
+result = if options[:mode] == :nsenum
+           enums.ns_enums.join("\n\n")
+         elsif options[:mode] == :swift
+           enums.swift_descriptions.join("\n")
+         else 
+           puts "Illegal mode: #{options[:mode]}"
+           exit -1
+         end
+
+
+output = if options[:outpath].nil? 
+          $stdout
+        else 
+          File.open(options[:outpath], "w")
+        end
+output.puts result
+output.close

--- a/swift/cocoaconv.rb
+++ b/swift/cocoaconv.rb
@@ -93,12 +93,17 @@ class String
 end
 
 module NSEnum
-  def type_name
-    type.camelize
-  end
-  
   def self.type_names(type)
-    return "MMD6#{type.camelize}", type.camelize
+    type_name = type.camelize
+    # Remove plural "S"
+    type_name = if type_name == "TokenTypes"
+                  "TokenType"
+                elsif type_name == "ParserExtensions"
+                  "ParserExtension"
+                else
+                  type_name
+                end
+    return "MMD6#{type_name}", type_name
   end
 
   def ns_enum
@@ -107,7 +112,8 @@ module NSEnum
       .map { |line| NSEnum.case(type_name, line) }
       .join("\n")
       
-    %Q{typedef NS_ENUM(NSUInteger, #{type_name}) {
+    return %Q{
+typedef NS_ENUM(NSUInteger, #{type_name}) {
 #{ns_enum_cases}
 } NS_SWIFT_NAME(#{swift_type_name});}
   end
@@ -211,7 +217,7 @@ input.close
 
 
 result = if options[:mode] == :nsenum
-           enums.ns_enums.join("\n\n")
+           enums.ns_enums.join("\n")
          elsif options[:mode] == :swift
            enums.swift_descriptions.join("\n")
          else 


### PR DESCRIPTION
I polished the script some more to be usable from the command line. It is located at `swift/cocoaconv.rb`.

The script supports a 2-step process:

1. generate `NS_ENUM` definitions in Objective-C that uses the naming conventions necessary for proper Swift bridging (default)
2. optionally generate more useful string representations for debugging in Swift (`-m swift` option)

## Example  output

```objc
typedef NS_ENUM(NSUInteger, MMD6ParserExtension) {
	MMD6ParserExtensionCompatibility = EXT_COMPATIBILITY,
	MMD6ParserExtensionComplete = EXT_COMPLETE,
	MMD6ParserExtensionSnippet = EXT_SNIPPET,
	MMD6ParserExtensionSmart = EXT_SMART,
	MMD6ParserExtensionNotes = EXT_NOTES,
	MMD6ParserExtensionNoLabels = EXT_NO_LABELS,
	MMD6ParserExtensionProcessHtml = EXT_PROCESS_HTML,
	MMD6ParserExtensionNoMetadata = EXT_NO_METADATA,
	MMD6ParserExtensionObfuscate = EXT_OBFUSCATE,
	MMD6ParserExtensionCritic = EXT_CRITIC,
	MMD6ParserExtensionCriticAccept = EXT_CRITIC_ACCEPT,
	MMD6ParserExtensionCriticReject = EXT_CRITIC_REJECT,
	MMD6ParserExtensionRandomFoot = EXT_RANDOM_FOOT,
	MMD6ParserExtensionTransclude = EXT_TRANSCLUDE,
	MMD6ParserExtensionFake = EXT_FAKE,
} NS_SWIFT_NAME(ParserExtension);
```

```swift
extension ParserExtension: CustomStringConvertible {
    public var description: String {
        switch self {
            case .compatibility: return "ParserExtension.compatibility"
            case .complete: return "ParserExtension.complete"
            case .snippet: return "ParserExtension.snippet"
            case .smart: return "ParserExtension.smart"
            case .notes: return "ParserExtension.notes"
            case .noLabels: return "ParserExtension.noLabels"
            case .processHtml: return "ParserExtension.processHtml"
            case .noMetadata: return "ParserExtension.noMetadata"
            case .obfuscate: return "ParserExtension.obfuscate"
            case .critic: return "ParserExtension.critic"
            case .criticAccept: return "ParserExtension.criticAccept"
            case .criticReject: return "ParserExtension.criticReject"
            case .randomFoot: return "ParserExtension.randomFoot"
            case .transclude: return "ParserExtension.transclude"
            case .fake: return "ParserExtension.fake"
        }
    }
}
```