### PR TITLE
fix target platform spelling (macosx, not macos)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ MACRO(ADD_PUBLIC_HEADER target filename)
 	
 	SET_TARGET_PROPERTIES(${target} PROPERTIES
 		XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS
-		"macos iphonesimulator iphoneos"
+		"macosx iphonesimulator iphoneos"
 	)
 
 	SET_TARGET_PROPERTIES(${target} PROPERTIES


### PR DESCRIPTION
With this change, the result of `make xcode` is configured so that you can build the libMultiMarkdown target not just for iOS but macOS devices as well.