### PR TITLE
FIXED: Properly identify AppleClang as Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ include_directories( ${PROJECT_SOURCE_DIR}/Sources/multimarkdown)
 include_directories( ${PROJECT_SOURCE_DIR}/test )
 include_directories(${PROJECT_BINARY_DIR})
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 	# using Clang
 	# Default is 256 -- needed for localization hash function
 	add_definitions("-fbracket-depth=264")	


### PR DESCRIPTION
multimarkdown 6.4.0 fails to build on macOS with the version of Clang included in Xcode:

```
fatal error: bracket nesting level exceeded maximum of 256
```

CMakeLists.txt contains code to increase the bracket nesting level for open-source Clang; this should be extended to do the same for Apple Clang. This PR does that.