### PR TITLE
FIXED: Fix PATH in convenience scripts

### DIFF
--- a/scripts/markdown
+++ b/scripts/markdown
@@ -8,7 +8,17 @@
 #
 
 # Be sure to include multimarkdown in our PATH
-export PATH="$PWD:/usr/local/bin:$PATH"
+unset CDPATH
+SCRIPT="$0"
+while
+	DIR="$(cd -P -- "$(dirname -- "$SCRIPT")" && pwd)"
+	test -h "$SCRIPT"
+do
+	SCRIPT="$(readlink "$SCRIPT")"
+	[ "$SCRIPT" = "${SCRIPT#/}" ] && SCRIPT="$DIR/$SCRIPT"
+done
+PATH="$DIR:/usr/local/bin:$PATH"
+export PATH
 
 which multimarkdown > /dev/null
 if [ $? = 1 ]

--- a/scripts/mmd
+++ b/scripts/mmd
@@ -8,7 +8,17 @@
 #
 
 # Be sure to include multimarkdown in our PATH
-export PATH="$PWD:/usr/local/bin:$PATH"
+unset CDPATH
+SCRIPT="$0"
+while
+	DIR="$(cd -P -- "$(dirname -- "$SCRIPT")" && pwd)"
+	test -h "$SCRIPT"
+do
+	SCRIPT="$(readlink "$SCRIPT")"
+	[ "$SCRIPT" = "${SCRIPT#/}" ] && SCRIPT="$DIR/$SCRIPT"
+done
+PATH="$DIR:/usr/local/bin:$PATH"
+export PATH
 
 which multimarkdown > /dev/null
 if [ $? = 1 ]

--- a/scripts/mmd2all
+++ b/scripts/mmd2all
@@ -9,7 +9,17 @@
 #
 
 # Be sure to include multimarkdown in our PATH
-export PATH="$PWD:/usr/local/bin:$PATH"
+unset CDPATH
+SCRIPT="$0"
+while
+	DIR="$(cd -P -- "$(dirname -- "$SCRIPT")" && pwd)"
+	test -h "$SCRIPT"
+do
+	SCRIPT="$(readlink "$SCRIPT")"
+	[ "$SCRIPT" = "${SCRIPT#/}" ] && SCRIPT="$DIR/$SCRIPT"
+done
+PATH="$DIR:/usr/local/bin:$PATH"
+export PATH
 
 which multimarkdown > /dev/null
 if [ $? = 1 ]

--- a/scripts/mmd2epub
+++ b/scripts/mmd2epub
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# mmd2oepub --- MultiMarkdown convenience script
+# mmd2epub --- MultiMarkdown convenience script
 #	<http://fletcherpenney.net/multimarkdown/>
 #	Fletcher T. Penney
 #
@@ -8,7 +8,17 @@
 #
 
 # Be sure to include multimarkdown in our PATH
-export PATH="$PWD:/usr/local/bin:$PATH"
+unset CDPATH
+SCRIPT="$0"
+while
+	DIR="$(cd -P -- "$(dirname -- "$SCRIPT")" && pwd)"
+	test -h "$SCRIPT"
+do
+	SCRIPT="$(readlink "$SCRIPT")"
+	[ "$SCRIPT" = "${SCRIPT#/}" ] && SCRIPT="$DIR/$SCRIPT"
+done
+PATH="$DIR:/usr/local/bin:$PATH"
+export PATH
 
 which multimarkdown > /dev/null
 if [ $? = 1 ]

--- a/scripts/mmd2fodt
+++ b/scripts/mmd2fodt
@@ -8,7 +8,17 @@
 #
 
 # Be sure to include multimarkdown in our PATH
-export PATH="$PWD:/usr/local/bin:$PATH"
+unset CDPATH
+SCRIPT="$0"
+while
+	DIR="$(cd -P -- "$(dirname -- "$SCRIPT")" && pwd)"
+	test -h "$SCRIPT"
+do
+	SCRIPT="$(readlink "$SCRIPT")"
+	[ "$SCRIPT" = "${SCRIPT#/}" ] && SCRIPT="$DIR/$SCRIPT"
+done
+PATH="$DIR:/usr/local/bin:$PATH"
+export PATH
 
 which multimarkdown > /dev/null
 if [ $? = 1 ]

--- a/scripts/mmd2odt
+++ b/scripts/mmd2odt
@@ -8,7 +8,17 @@
 #
 
 # Be sure to include multimarkdown in our PATH
-export PATH="$PWD:/usr/local/bin:$PATH"
+unset CDPATH
+SCRIPT="$0"
+while
+	DIR="$(cd -P -- "$(dirname -- "$SCRIPT")" && pwd)"
+	test -h "$SCRIPT"
+do
+	SCRIPT="$(readlink "$SCRIPT")"
+	[ "$SCRIPT" = "${SCRIPT#/}" ] && SCRIPT="$DIR/$SCRIPT"
+done
+PATH="$DIR:/usr/local/bin:$PATH"
+export PATH
 
 which multimarkdown > /dev/null
 if [ $? = 1 ]

--- a/scripts/mmd2opml
+++ b/scripts/mmd2opml
@@ -8,7 +8,17 @@
 #
 
 # Be sure to include multimarkdown in our PATH
-export PATH="$PWD:/usr/local/bin:$PATH"
+unset CDPATH
+SCRIPT="$0"
+while
+	DIR="$(cd -P -- "$(dirname -- "$SCRIPT")" && pwd)"
+	test -h "$SCRIPT"
+do
+	SCRIPT="$(readlink "$SCRIPT")"
+	[ "$SCRIPT" = "${SCRIPT#/}" ] && SCRIPT="$DIR/$SCRIPT"
+done
+PATH="$DIR:/usr/local/bin:$PATH"
+export PATH
 
 which multimarkdown > /dev/null
 if [ $? = 1 ]

--- a/scripts/mmd2pdf
+++ b/scripts/mmd2pdf
@@ -15,7 +15,17 @@
 #		LaTeX file.
 
 # Be sure to include multimarkdown and latex in our PATH
-export PATH="$PWD:/usr/local/bin:/usr/texbin:/Library/TeX/texbin:$PATH"
+unset CDPATH
+SCRIPT="$0"
+while
+	DIR="$(cd -P -- "$(dirname -- "$SCRIPT")" && pwd)"
+	test -h "$SCRIPT"
+do
+	SCRIPT="$(readlink "$SCRIPT")"
+	[ "$SCRIPT" = "${SCRIPT#/}" ] && SCRIPT="$DIR/$SCRIPT"
+done
+PATH="$DIR:/usr/local/bin:/usr/texbin:/Library/TeX/texbin:$PATH"
+export PATH
 
 which multimarkdown > /dev/null
 if [ $? = 1 ]

--- a/scripts/mmd2tex
+++ b/scripts/mmd2tex
@@ -8,7 +8,17 @@
 #
 
 # Be sure to include multimarkdown in our PATH
-export PATH="$PWD:/usr/local/bin:$PATH"
+unset CDPATH
+SCRIPT="$0"
+while
+	DIR="$(cd -P -- "$(dirname -- "$SCRIPT")" && pwd)"
+	test -h "$SCRIPT"
+do
+	SCRIPT="$(readlink "$SCRIPT")"
+	[ "$SCRIPT" = "${SCRIPT#/}" ] && SCRIPT="$DIR/$SCRIPT"
+done
+PATH="$DIR:/usr/local/bin:$PATH"
+export PATH
 
 which multimarkdown > /dev/null
 if [ $? = 1 ]


### PR DESCRIPTION
The convenience scripts fail to find `multimarkdown`, unless it is in the user's `PATH`:

```
$ export PATH=/usr/bin:/bin
$ /opt/local/bin/multimarkdown --help | sed -n 2p
MultiMarkdown v6.4.0 -- Copyright © 2016 - 2018 Fletcher T. Penney.
$ /opt/local/bin/mmd --help
multimarkdown executable not found!
```

This was originally [reported to MacPorts](https://trac.macports.org/ticket/55805) by @angelog0.

The convenience scripts contain code to "include `multimarkdown` in our `PATH`", but the code is incorrect, because it only adds `$PWD` to `PATH`. It is unlikely that the user's shell is changed to the directory that contains the `multimarkdown` executable.

It is likely that the convenience scripts have been installed to the same directory where the `multimarkdown` executable is installed. This PR fixes the problem by adding *that* directory to `PATH`.

The code is a little verbose because it resolves symlinks, and because I've tried to make it POSIX compatible, which I assume is desired given your scripts' existing `#!/bin/sh` shebang line. For example, it does not use `readlink -f`, since that is a GNU `readlink` extension that is not present in the BSD version of `readlink`. Resolving symlinks is desired, because the user may have made a symlink of one of the convenience scripts in another directory, without also making a symlink of the `multimarkdown` executable in that directory, and the convenience script should still function when accessed via that symlink.

`CDPATH` is unset, because if a user has exported it, it can affect the functionality of `cd`.

I've also separated setting `PATH` and exporting it onto two lines. Some shells cannot handle both being on the same line.

I'm unclear why /usr/local/bin is being added to `PATH`, but I haven't changed that in this PR.