### PR TITLE
FIXED: Use "command -v" instead of "which"

### DIFF
--- a/scripts/markdown
+++ b/scripts/markdown
@@ -10,8 +10,7 @@
 # Be sure to include multimarkdown in our PATH
 export PATH="$PWD:/usr/local/bin:$PATH"
 
-which multimarkdown > /dev/null
-if [ $? = 1 ]
+if ! command -v multimarkdown >/dev/null 2>&1
 then
 	echo multimarkdown executable not found! >&2
 	exit 1

--- a/scripts/mmd
+++ b/scripts/mmd
@@ -10,8 +10,7 @@
 # Be sure to include multimarkdown in our PATH
 export PATH="$PWD:/usr/local/bin:$PATH"
 
-which multimarkdown > /dev/null
-if [ $? = 1 ]
+if ! command -v multimarkdown >/dev/null 2>&1
 then
 	echo multimarkdown executable not found! >&2
 	exit 1

--- a/scripts/mmd2all
+++ b/scripts/mmd2all
@@ -11,8 +11,7 @@
 # Be sure to include multimarkdown in our PATH
 export PATH="$PWD:/usr/local/bin:$PATH"
 
-which multimarkdown > /dev/null
-if [ $? = 1 ]
+if ! command -v multimarkdown >/dev/null 2>&1
 then
 	echo multimarkdown executable not found! >&2
 	exit 1

--- a/scripts/mmd2epub
+++ b/scripts/mmd2epub
@@ -10,8 +10,7 @@
 # Be sure to include multimarkdown in our PATH
 export PATH="$PWD:/usr/local/bin:$PATH"
 
-which multimarkdown > /dev/null
-if [ $? = 1 ]
+if ! command -v multimarkdown >/dev/null 2>&1
 then
 	echo multimarkdown executable not found! >&2
 	exit 1

--- a/scripts/mmd2fodt
+++ b/scripts/mmd2fodt
@@ -10,8 +10,7 @@
 # Be sure to include multimarkdown in our PATH
 export PATH="$PWD:/usr/local/bin:$PATH"
 
-which multimarkdown > /dev/null
-if [ $? = 1 ]
+if ! command -v multimarkdown >/dev/null 2>&1
 then
 	echo multimarkdown executable not found! >&2
 	exit 1

--- a/scripts/mmd2odt
+++ b/scripts/mmd2odt
@@ -10,8 +10,7 @@
 # Be sure to include multimarkdown in our PATH
 export PATH="$PWD:/usr/local/bin:$PATH"
 
-which multimarkdown > /dev/null
-if [ $? = 1 ]
+if ! command -v multimarkdown >/dev/null 2>&1
 then
 	echo multimarkdown executable not found! >&2
 	exit 1

--- a/scripts/mmd2opml
+++ b/scripts/mmd2opml
@@ -10,8 +10,7 @@
 # Be sure to include multimarkdown in our PATH
 export PATH="$PWD:/usr/local/bin:$PATH"
 
-which multimarkdown > /dev/null
-if [ $? = 1 ]
+if ! command -v multimarkdown >/dev/null 2>&1
 then
 	echo multimarkdown executable not found! >&2
 	exit 1

--- a/scripts/mmd2pdf
+++ b/scripts/mmd2pdf
@@ -17,8 +17,7 @@
 # Be sure to include multimarkdown and latex in our PATH
 export PATH="$PWD:/usr/local/bin:/usr/texbin:/Library/TeX/texbin:$PATH"
 
-which multimarkdown > /dev/null
-if [ $? = 1 ]
+if ! command -v multimarkdown >/dev/null 2>&1
 then
 	echo multimarkdown executable not found! >&2
 	exit 1

--- a/scripts/mmd2tex
+++ b/scripts/mmd2tex
@@ -10,8 +10,7 @@
 # Be sure to include multimarkdown in our PATH
 export PATH="$PWD:/usr/local/bin:$PATH"
 
-which multimarkdown > /dev/null
-if [ $? = 1 ]
+if ! command -v multimarkdown >/dev/null 2>&1
 then
 	echo multimarkdown executable not found! >&2
 	exit 1


### PR DESCRIPTION
The behavior of `which` is not standardized by POSIX. Some old implementations print their error messages to stdout instead of stderr, and don't return a nonzero exit code when they fail to find the given program. `command -v` on the other hand is in POSIX (optional in 2004 and required as of 2008).