### PR TITLE
added support for cross-compiling for msdos-djgpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,12 @@ windows-zip-32: $(BUILD_DIR)
 	cd $(BUILD_DIR); touch README.html; \
 	cmake -DCMAKE_TOOLCHAIN_FILE=../tools/Toolchain-MinGW-w64-32bit.cmake -DCMAKE_BUILD_TYPE=Release -DZIP=1 ..
 
+# Cross-compile for msdos using djgpp on *nix
+.PHONY : djgpp
+djgpp: $(BUILD_DIR)
+	cd $(BUILD_DIR); touch README.html; \
+	cmake -DDJGPP=1 -DCMAKE_TOOLCHAIN_FILE=../tools/Toolchain-djgpp.cmake -DCMAKE_BUILD_TYPE=Release ..
+
 # Build the documentation using doxygen
 .PHONY : documentation
 documentation:

--- a/Sources/multimarkdown/argtable3.c
+++ b/Sources/multimarkdown/argtable3.c
@@ -355,7 +355,7 @@ static const char illoptstring[] = "unknown option -- %s";
 
 
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined (DJGPP)
 
 /* Windows needs warnx().  We change the definition though:
  *  1. (another) global is defined, opterrmsg, which holds the error message
@@ -380,7 +380,11 @@ static void warnx(const char *fmt, ...)
     */
     memset(opterrmsg, 0, sizeof opterrmsg);
 	if (fmt != NULL)
+#ifdef DJGPP
+		vsnprintf(opterrmsg, sizeof(opterrmsg) - 1, fmt, ap);
+#else
 		_vsnprintf(opterrmsg, sizeof(opterrmsg) - 1, fmt, ap);
+#fi
 	va_end(ap);
 
 #pragma warning(suppress: 6053)
@@ -389,7 +393,7 @@ static void warnx(const char *fmt, ...)
 
 #else
 #include <err.h>
-#endif /*_WIN32*/
+#endif /*_WIN32 or DJGPP*/
 
 
 /*

--- a/Sources/multimarkdown/main.c
+++ b/Sources/multimarkdown/main.c
@@ -54,7 +54,9 @@
 */
 
 #include <ctype.h>
+#ifndef DJGPP
 #include <libgen.h>
+#endif
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tools/Toolchain-djgpp.cmake
+++ b/tools/Toolchain-djgpp.cmake
@@ -2,11 +2,9 @@
 
 set (IS_CROSSCOMPILING "YES")
 set (IS_32_BIT "32-")
-
-set (CMAKE_SYSTEM_NAME DJGPP)
+set (CMAKE_C_FLAGS "-DDJGPP")
 
 set (CMAKE_C_COMPILER i586-pc-msdosdjgpp-gcc)
 set (CMAKE_CXX_COMPILER i586-pc-msdosdjgpp-g++)
-set (CMAKE_RC_COMPILER i586-pc-msdosdjgpp-windres)
 
 set (CMAKE_FIND_ROOT_PATH /usr/bin)

--- a/tools/Toolchain-djgpp.cmake
+++ b/tools/Toolchain-djgpp.cmake
@@ -1,0 +1,12 @@
+# Settings for compiling for djgpp 32-bit machines
+
+set (IS_CROSSCOMPILING "YES")
+set (IS_32_BIT "32-")
+
+set (CMAKE_SYSTEM_NAME DJGPP)
+
+set (CMAKE_C_COMPILER i586-pc-msdosdjgpp-gcc)
+set (CMAKE_CXX_COMPILER i586-pc-msdosdjgpp-g++)
+set (CMAKE_RC_COMPILER i586-pc-msdosdjgpp-windres)
+
+set (CMAKE_FIND_ROOT_PATH /usr/bin)


### PR DESCRIPTION
To tell the truth, perhaps I should have called the changes "dos" instead of "djgpp".