### PR TITLE
Rename "mmd-" to "mmd6-" in some includes that were missed.

### DIFF
--- a/texmf/tex/latex/mmd6/beamer/mmd6-beamer-begin.tex
+++ b/texmf/tex/latex/mmd6/beamer/mmd6-beamer-begin.tex
@@ -28,7 +28,7 @@
 \fi
 
 
-%\input{mmd-title}
+%\input{mmd6-title}
 
 % Show "current/total" slide counter in footer
 \title[\mytitle\hspace{2em}\insertframenumber/

--- a/texmf/tex/latex/mmd6/beamer/mmd6-beamer-leader.tex
+++ b/texmf/tex/latex/mmd6/beamer/mmd6-beamer-leader.tex
@@ -32,7 +32,7 @@
 
 
 % Configure default metadata
-\input{mmd-default-metadata}
+\input{mmd6-default-metadata}
 
 
 \AtBeginSection[]

--- a/texmf/tex/latex/mmd6/letterhead/mmd6-letterhead-begin.tex
+++ b/texmf/tex/latex/mmd6/letterhead/mmd6-letterhead-begin.tex
@@ -158,7 +158,7 @@
 \renewcommand{\baselinestretch}{1.2}
 \setlength{\parskip}{12pt}
 
-%\input{mmd-title}
+%\input{mmd6-title}
 
 % Insert Recipient
 \myrecipient


### PR DESCRIPTION
The beamer template wasn't working for me because it referenced `mmd-default-metadata` instead of `mmd6-default-metadata`. Two of the three changes were already commented out but I included them for the sake of completeness.

There is still `mmd-letterhead.sty` and `mmd-envelope.sty` but I left them alone as I wasn't sure if they should be renamed as well.