### PR TITLE
use image title as short cation listing in lof

### DIFF
--- a/Sources/libMultiMarkdown/latex.c
+++ b/Sources/libMultiMarkdown/latex.c
@@ -417,7 +417,11 @@ void mmd_export_image_latex(DString * out, const char * source, token * text, li
 		print_const("\n");
 
 		if (text) {
-			print_const("\\caption{");
+			if (link->title && link->title[0] != '\0') {
+				printf("\\caption[%s]{", link->title);
+			} else {
+				print_const("\\caption{");
+			}
 			mmd_export_token_tree_latex(out, source, text->child, scratch);
 			print_const("}\n");
 		}


### PR DESCRIPTION
I happen to have very long captions in my thesis, so i made a simple modification to MMDs LaTeX mode, to use the image title as short cation listing in the list of figures:

    ![Very very looooooooooooong caption](/path/to/img.jpg "Optional lof caption")

generates

    \caption[Optional lof caption]{Very very looooooooooooong caption}

in LaTeX mode.