### PR TITLE
Correct the FSF address in some tex files licenses.

### DIFF
--- a/texmf/tex/latex/mmd6/letterhead/mmd-envelope.sty
+++ b/texmf/tex/latex/mmd6/letterhead/mmd-envelope.sty
@@ -23,8 +23,8 @@
 % You should have received a copy of the GNU General Public License
 % along with this program; if not, write to the
 %    Free Software Foundation, Inc.
-%    59 Temple Place, Suite 330
-%    Boston, MA 02111-1307 USA
+%    51 Franklin Street, Fifth Floor
+%    Boston, MA 02110-1301 USA
 
 
 \ProvidesPackage{mmd-envelope}

--- a/texmf/tex/latex/mmd6/letterhead/mmd-letterhead.sty
+++ b/texmf/tex/latex/mmd6/letterhead/mmd-letterhead.sty
@@ -23,8 +23,8 @@
 % You should have received a copy of the GNU General Public License
 % along with this program; if not, write to the
 %    Free Software Foundation, Inc.
-%    59 Temple Place, Suite 330
-%    Boston, MA 02111-1307 USA
+%    51 Franklin Street, Fifth Floor
+%    Boston, MA 02110-1301 USA
 
 
 \ProvidesPackage{mmd-letterhead}


### PR DESCRIPTION
This is actually asked by the reviewer in order to add MultiMarkdown to the Fedora repositories.

Basically, these files where showing an [outdated FSF address](https://fedoraproject.org/wiki/Common_Rpmlint_issues#incorrect-fsf-address) and are from the MultiMarkdown-4 era.

See : https://bugzilla.redhat.com/show_bug.cgi?id=1801451#c1