### PR TITLE
src/argtable3.c: Fix buffer overrun issue as detected by GCC 10.2

### DIFF
--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -4650,6 +4650,8 @@ int arg_parse(int argc, char * *argv, void * *argtable) {
  * of chars.
  * Does not append more than *pndest chars into *pdest[]
  * so as to prevent buffer overruns.
+ * Requires *pndest > 0 and then keeps *pndest > 0
+ * to account for the terminating '\0' that is always written.
  * Its something like strncat() but more efficient for repeated
  * calls on the same destination string.
  * Example of use:
@@ -4666,7 +4668,7 @@ int arg_parse(int argc, char * *argv, void * *argtable) {
 static
 void arg_cat(char * *pdest, const char * src, size_t * pndest) {
 	char * dest = *pdest;
-	char * end  = dest + *pndest;
+	char * end  = dest + *pndest - 1;
 
 	/*locate null terminator of dest string */
 	while (dest < end && *dest != 0) {
@@ -4682,7 +4684,7 @@ void arg_cat(char * *pdest, const char * src, size_t * pndest) {
 	*dest = 0;
 
 	/* update *pdest and *pndest */
-	*pndest = end - dest;
+	*pndest = end - dest + 1;
 	*pdest  = dest;
 }
 


### PR DESCRIPTION
When building multimarkdown 6.6.0 with GCC 10.2, I got this amazing warning (with source tree prefix abbreviated as `...`):

~~~gcc
In function ‘arg_cat’,
    inlined from ‘arg_cat_option’ at .../src/argtable3.c:4420:13,
    inlined from ‘arg_print_syntax’ at .../src/argtable3.c:4617:9:
.../src/argtable3.c:4351:11: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 4351 |     *dest = 0;
      |     ~~~~~~^~~
.../src/argtable3.c: In function ‘arg_print_syntax’:
.../src/argtable3.c:4606:14: note: at offset 200 to object ‘syntax’ with size 200 declared here
 4606 |         char syntax[200] = "";
      |              ^~~~~~
~~~

and it is true: `arg_cat`s promise to never write more than `*pndest` characters is not kept when truncating because the always-written `'\0'` terminator lands at `*dest` with `dest==end` which points *past* the available buffer.

To keep the usage patterns intact, `end` must point at the farthest position available for a `'\0'` terminator, so it must be reduced by 1.
To keep `*pndest` reflecting the remaining buffer size (including the `'\0'`), the update to `*pndest` must counteract the above correction, hence be increased by 1.

I have updated the description of `arg_cat` in the comments accordingly.

I have not corrected the function name in the description as that is unrelated.
