### PR TITLE
Fix in order to compile in XeLaTeX

### DIFF
--- a/texmf/tex/latex/mmd6/tufte-book/mmd6-tufte-book-leader.tex
+++ b/texmf/tex/latex/mmd6/tufte-book/mmd6-tufte-book-leader.tex
@@ -36,6 +36,8 @@
 \makeglossaries
 \makeindex
 
+\renewcommand\allcapsspacing[1]{{\addfontfeature{LetterSpace=15}#1}}  
+\renewcommand\smallcapsspacing[1]{{\addfontfeature{LetterSpace=10}#1}}
 
 % Configure default metadata to avoid errors
 \input{mmd6-default-metadata}


### PR DESCRIPTION
Hi Fletcher, hope you are doing fine. As it is right now, the Tufte template won't compile at all using XeLaTeX. This small change should fix this.