### PR TITLE
Consistently use `unsigned short` in token.h

### DIFF
--- a/src/token.c
+++ b/src/token.c
@@ -632,7 +632,7 @@ void token_trim_whitespace(token * t, const char * string) {
 
 /// Check whether first token in the chain matches the given type.
 /// If so, return and advance the chain.
-token * token_chain_accept(token ** t, short type) {
+token * token_chain_accept(token ** t, unsigned short type) {
 	token * result = NULL;
 
 	if (t && *t && ((*t)->type == type)) {
@@ -665,7 +665,7 @@ token * token_chain_accept_multiple(token ** t, int n, ...) {
 }
 
 
-void token_skip_until_type(token ** t, short type) {
+void token_skip_until_type(token ** t, unsigned short type) {
 	while ((*t) && ((*t)->type != type)) {
 		*t = (*t)->next;
 	}

--- a/src/token.h
+++ b/src/token.h
@@ -231,11 +231,11 @@ void token_trim_whitespace(token * t, const char * string);
 
 
 ///
-token * token_chain_accept(token ** t, short type);
+token * token_chain_accept(token ** t, unsigned short type);
 
 token * token_chain_accept_multiple(token ** t, int n, ...);
 
-void token_skip_until_type(token ** t, short type);
+void token_skip_until_type(token ** t, unsigned short type);
 
 void token_skip_until_type_multiple(token ** t, int n, ...);
 


### PR DESCRIPTION
Just noticed this when I had stricter warnings turned on -- the `token.h` was expecting a `short` as type parameter for 2 functions, while all the others would use `unsigned short`.

They use the same bit pattern in memory, so there wouldn't be any problem with that. It's more a cosmetic change for consistency in the headers and the API.

Also (I know that's not a big motivator for you :))  you would have to cast Int16 to/from UInt16 with Swift just for these 2 functions. With the fix, it takes the `token->type` directly without complaining about type mismatch.

- `build/ctest` passes: `100% tests passed, 0 tests failed out of 11`