### PR TITLE
ci: added github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure make
+      run: make release
+
+    - name: Test build
+      run: cd build && make all
+
+    - name: Test install
+      run: cd build && sudo make install
+      
+    - name: Run tests
+      run: cd build && ctest


### PR DESCRIPTION
I've noticed the CI kept failing so why not switch to Github Actions?

So far it just runs `make all`, `make install` and `ctest`.