### PR TITLE
Avoid space to be eaten aways after a slash in latex export

### DIFF
--- a/src/latex.c
+++ b/src/latex.c
@@ -100,7 +100,7 @@ void mmd_print_char_latex(DString * out, char c) {
 			break;
 
 		case '/':
-			print_const("\\slash ");
+			print_const("\\slash{}");
 			break;
 
 		case '^':
@@ -1856,7 +1856,7 @@ parse_citation:
 			break;
 
 		case SLASH:
-			print_const("\\slash ");
+			print_const("\\slash{}");
 			break;
 
 		case STAR:
@@ -2288,7 +2288,7 @@ void mmd_export_token_latex_tt(DString * out, const char * source, token * t, sc
 			break;
 
 		case SLASH:
-			print_const("\\slash ");
+			print_const("\\slash{}");
 			break;
 
 		case TEXT_BACKSLASH:

--- a/tests/Beamer/What Is MMD.tex
+++ b/tests/Beamer/What Is MMD.tex
@@ -2,8 +2,8 @@
 \def\mytitle{What is MultiMarkdown?}
 \def\subtitle{And why should you care?}
 \def\myauthor{Fletcher T. Penney}
-\def\affiliation{http:\slash \slash fletcherpenney.net\slash multimarkdown\slash }
-\def\mycopyright{2009-2011 Fletcher T. Penney. This work is licensed under a Creative Commons License. http:\slash \slash creativecommons.org\slash licenses\slash by-sa\slash 2.5\slash }
+\def\affiliation{http:\slash{}\slash{}fletcherpenney.net\slash{}multimarkdown\slash{}}
+\def\mycopyright{2009-2011 Fletcher T. Penney. This work is licensed under a Creative Commons License. http:\slash{}\slash{}creativecommons.org\slash{}licenses\slash{}by-sa\slash{}2.5\slash{}}
 \input{mmd-natbib-plain}
 \def\theme{keynote-gradient}
 \input{mmd6-beamer-begin}
@@ -12,7 +12,7 @@
 \frametitle{MultiMarkdown is a derivative of Markdown}
 \label{multimarkdownisaderivativeofmarkdown}
 
-\href{http://daringfireball.net/projects/markdown/}{Markdown}\footnote{\href{http://daringfireball.net/projects/markdown/}{http:\slash \slash daringfireball.net\slash projects\slash markdown\slash }} is a program and a
+\href{http://daringfireball.net/projects/markdown/}{Markdown}\footnote{\href{http://daringfireball.net/projects/markdown/}{http:\slash{}\slash{}daringfireball.net\slash{}projects\slash{}markdown\slash{}}} is a program and a
 syntax by John Gruber that allows you to easily convert plain text into HTML
 suitable for using on a web page.
 
@@ -120,9 +120,9 @@ programmers.
 
 \begin{itemize}
 \item Outside of the actual syntax, MMD supports multiple output formats,
-including HTML, \href{http://en.wikipedia.org/wiki/LaTeX}{LaTeX}\footnote{\href{http://en.wikipedia.org/wiki/LaTeX}{http:\slash \slash en.wikipedia.org\slash wiki\slash LaTeX}},
-\href{http://en.wikipedia.org/wiki/OpenDocument}{OpenDocument}\footnote{\href{http://en.wikipedia.org/wiki/OpenDocument}{http:\slash \slash en.wikipedia.org\slash wiki\slash OpenDocument}}, and
-\href{http://en.wikipedia.org/wiki/OPML}{OPML}\footnote{\href{http://en.wikipedia.org/wiki/OPML}{http:\slash \slash en.wikipedia.org\slash wiki\slash OPML}}
+including HTML, \href{http://en.wikipedia.org/wiki/LaTeX}{LaTeX}\footnote{\href{http://en.wikipedia.org/wiki/LaTeX}{http:\slash{}\slash{}en.wikipedia.org\slash{}wiki\slash{}LaTeX}},
+\href{http://en.wikipedia.org/wiki/OpenDocument}{OpenDocument}\footnote{\href{http://en.wikipedia.org/wiki/OpenDocument}{http:\slash{}\slash{}en.wikipedia.org\slash{}wiki\slash{}OpenDocument}}, and
+\href{http://en.wikipedia.org/wiki/OPML}{OPML}\footnote{\href{http://en.wikipedia.org/wiki/OPML}{http:\slash{}\slash{}en.wikipedia.org\slash{}wiki\slash{}OPML}}
 
 \item This allows you to use the same markup language (MultiMarkdown) to create a
 high quality pdf (article, book, or presentation like this one) without any
@@ -166,7 +166,7 @@ take.
 
 Built into MultiMarkdown is support for mathematical equations. You write
 using LaTeX syntax. When you output to HTML, you can use
-\href{http://www.mathjax.org/}{MathJax}\footnote{\href{http://www.mathjax.org/}{http:\slash \slash www.mathjax.org\slash }} to properly display the math. If you output
+\href{http://www.mathjax.org/}{MathJax}\footnote{\href{http://www.mathjax.org/}{http:\slash{}\slash{}www.mathjax.org\slash{}}} to properly display the math. If you output
 to LaTeX, it is display automatically. There is not currently an approach to
 display math using OpenDocument
 
@@ -209,7 +209,7 @@ becomes{\ldots}
 \label{supportforabibliographyisalsoincluded}
 
 \begin{itemize}
-\item MultiMarkdown has support for \href{http://www.bibtex.org/}{BibTeX}\footnote{\href{http://www.bibtex.org/}{http:\slash \slash www.bibtex.org\slash }}, or
+\item MultiMarkdown has support for \href{http://www.bibtex.org/}{BibTeX}\footnote{\href{http://www.bibtex.org/}{http:\slash{}\slash{}www.bibtex.org\slash{}}}, or
 for just including your own citations, so that you can back up your
 arguments.~\citep[p. 42]{fake}
 
@@ -249,7 +249,7 @@ If your editor supports fonts, italics, etc. then be sure to save as a plain
 text file (not a .doc, RTF, or other ``rich'' format).
 
 \item Some applications include built-in support for MultiMarkdown in various
-ways. There's a \href{http://fletcher.github.com/markdown.tmbundle/}{bundle}\footnote{\href{http://fletcher.github.com/markdown.tmbundle/}{http:\slash \slash fletcher.github.com\slash markdown.tmbundle\slash }} for \href{http://macromates.com/}{TextMate}\footnote{\href{http://macromates.com/}{http:\slash \slash macromates.com\slash }}, and \href{http://www.literatureandlatte.com/scrivener.html}{Scrivener}\footnote{\href{http://www.literatureandlatte.com/scrivener.html}{http:\slash \slash www.literatureandlatte.com\slash scrivener.html}} includes
+ways. There's a \href{http://fletcher.github.com/markdown.tmbundle/}{bundle}\footnote{\href{http://fletcher.github.com/markdown.tmbundle/}{http:\slash{}\slash{}fletcher.github.com\slash{}markdown.tmbundle\slash{}}} for \href{http://macromates.com/}{TextMate}\footnote{\href{http://macromates.com/}{http:\slash{}\slash{}macromates.com\slash{}}}, and \href{http://www.literatureandlatte.com/scrivener.html}{Scrivener}\footnote{\href{http://www.literatureandlatte.com/scrivener.html}{http:\slash{}\slash{}www.literatureandlatte.com\slash{}scrivener.html}} includes
 MultiMarkdown support.
 
 \end{itemize}
@@ -293,11 +293,11 @@ file into a pdf.
 \label{wheretolearnmore}
 
 \begin{itemize}
-\item \href{http://fletcherpenney.net/multimarkdown/}{http:\slash \slash fletcherpenney.net\slash multimarkdown\slash }
+\item \href{http://fletcherpenney.net/multimarkdown/}{http:\slash{}\slash{}fletcherpenney.net\slash{}multimarkdown\slash{}}
 
-\item \href{http://groups.google.com/group/multimarkdown/}{http:\slash \slash groups.google.com\slash group\slash multimarkdown\slash }
+\item \href{http://groups.google.com/group/multimarkdown/}{http:\slash{}\slash{}groups.google.com\slash{}group\slash{}multimarkdown\slash{}}
 
-\item \href{http://fletcher.github.com/MultiMarkdown-Gallery/}{http:\slash \slash fletcher.github.com\slash MultiMarkdown-Gallery\slash }
+\item \href{http://fletcher.github.com/MultiMarkdown-Gallery/}{http:\slash{}\slash{}fletcher.github.com\slash{}MultiMarkdown-Gallery\slash{}}
 
 \end{itemize}
 
@@ -320,7 +320,7 @@ It uses the \texttt{beamer} XSLT file, and the \texttt{keynote-gradient} beamer 
 \begin{thebibliography}{0}
 
 \bibitem{gruber}
-John Gruber. Daring Fireball: Markdown. {[Cited January 2006]}. Available from \href{http://daringfireball.net/projects/markdown/}{http:\slash \slash daringfireball.net\slash projects\slash markdown\slash }.
+John Gruber. Daring Fireball: Markdown. {[Cited January 2006]}. Available from \href{http://daringfireball.net/projects/markdown/}{http:\slash{}\slash{}daringfireball.net\slash{}projects\slash{}markdown\slash{}}.
 
 \bibitem{fake}
 John Doe. \emph{A Totally Fake Book}. Vanity Press, 2006.

--- a/tests/MMD6Tests/Amps and Angles.tex
+++ b/tests/MMD6Tests/Amps and Angles.tex
@@ -14,13 +14,13 @@ This \& that.
 
 5
 
-Here is a \href{http://example.com/?foo=1&bar=2}{link}\footnote{\href{http://example.com/?foo=1&bar=2}{http:\slash \slash example.com\slash ?foo=1\&bar=2}} with an ampersand in the URL.
+Here is a \href{http://example.com/?foo=1&bar=2}{link}\footnote{\href{http://example.com/?foo=1&bar=2}{http:\slash{}\slash{}example.com\slash{}?foo=1\&bar=2}} with an ampersand in the URL.
 
-Here is a link with an amersand in the link text: \href{http://att.com/}{AT\&T}\footnote{\href{http://att.com/}{http:\slash \slash att.com\slash }}.
+Here is a link with an amersand in the link text: \href{http://att.com/}{AT\&T}\footnote{\href{http://att.com/}{http:\slash{}\slash{}att.com\slash{}}}.
 
-Here is an inline \href{/script%20here?foo=1&bar=2}{link}\footnote{\href{/script%20here?foo=1&bar=2}{\slash script\%20here?foo=1\&bar=2}}.
+Here is an inline \href{/script%20here?foo=1&bar=2}{link}\footnote{\href{/script%20here?foo=1&bar=2}{\slash{}script\%20here?foo=1\&bar=2}}.
 
-Here is an inline \href{/script%20here?foo=1&bar=2}{link}\footnote{\href{/script%20here?foo=1&bar=2}{\slash script\%20here?foo=1\&bar=2}}.
+Here is an inline \href{/script%20here?foo=1&bar=2}{link}\footnote{\href{/script%20here?foo=1&bar=2}{\slash{}script\%20here?foo=1\&bar=2}}.
 
 \begin{verbatim}
 & and &amp; and < and > in code block.

--- a/tests/MMD6Tests/Automatic Links.tex
+++ b/tests/MMD6Tests/Automatic Links.tex
@@ -2,7 +2,7 @@
 \def\mytitle{Automatic Links}
 \input{mmd6-article-begin}
 
-\href{http://foo.com/}{http:\slash \slash foo.com\slash }
+\href{http://foo.com/}{http:\slash{}\slash{}foo.com\slash{}}
 
 \href{mailto:foo@bar.com}{foo@bar.com}
 

--- a/tests/MMD6Tests/Edge Cases.tex
+++ b/tests/MMD6Tests/Edge Cases.tex
@@ -97,7 +97,7 @@ This is \emph{\textbf{another} test} of \emph{italics} and \textbf{bold}.
 
 *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a *a
 
-\href{http://foo.bar}{foo *bar}\footnote{\href{http://foo.bar}{http:\slash \slash foo.bar}} foo* \emph{bar}
+\href{http://foo.bar}{foo *bar}\footnote{\href{http://foo.bar}{http:\slash{}\slash{}foo.bar}} foo* \emph{bar}
 
 30
 

--- a/tests/MMD6Tests/Escapes.tex
+++ b/tests/MMD6Tests/Escapes.tex
@@ -66,7 +66,7 @@ $>$
 
 \textbackslash{}
 
-\slash 
+\slash{}
 
 \^{}
 
@@ -116,7 +116,7 @@ foo~bar
 
 45
 
-\href{https://www.test.com/foo?bar=XXX-YYY&x=400}{foo}\footnote{\href{https://www.test.com/foo?bar=XXX-YYY&x=400}{https:\slash \slash www.test.com\slash foo?bar=XXX-YYY\&x=400}}
+\href{https://www.test.com/foo?bar=XXX-YYY&x=400}{foo}\footnote{\href{https://www.test.com/foo?bar=XXX-YYY&x=400}{https:\slash{}\slash{}www.test.com\slash{}foo?bar=XXX-YYY\&x=400}}
 
 \input{mmd6-article-footer}
 \end{document}

--- a/tests/MMD6Tests/Fuzz.tex
+++ b/tests/MMD6Tests/Fuzz.tex
@@ -4,7 +4,7 @@
 
 \input{mmd6-article-begin}
 
-Collection of test cases identified by \href{http://lcamtuf.coredump.cx/afl/}{American fuzzy lop}\footnote{\href{http://lcamtuf.coredump.cx/afl/}{http:\slash \slash lcamtuf.coredump.cx\slash afl\slash }}.
+Collection of test cases identified by \href{http://lcamtuf.coredump.cx/afl/}{American fuzzy lop}\footnote{\href{http://lcamtuf.coredump.cx/afl/}{http:\slash{}\slash{}lcamtuf.coredump.cx\slash{}afl\slash{}}}.
 
 û\ensuremath{\sim}\ensuremath{\sim}foo~&gt;bar~~\}
 

--- a/tests/MMD6Tests/Inline Footnotes.tex
+++ b/tests/MMD6Tests/Inline Footnotes.tex
@@ -5,7 +5,7 @@
 Inline.\footnote{foo \emph{bar}}
 
 Inline.\footnote{foo \emph{bar}
-\href{/bar}{foo}\footnote{\href{/bar}{\slash bar}}
+\href{/bar}{foo}\footnote{\href{/bar}{\slash{}bar}}
 \textbf{foo}.}
 
 Inline.\footnote{foo \emph{bar}}

--- a/tests/MMD6Tests/Inline Links.tex
+++ b/tests/MMD6Tests/Inline Links.tex
@@ -2,50 +2,50 @@
 \def\mytitle{Inline Links}
 \input{mmd6-article-begin}
 
-Just a \href{http://url/file.txt}{URL}\footnote{\href{http://url/file.txt}{http:\slash \slash url\slash file.txt}}.
+Just a \href{http://url/file.txt}{URL}\footnote{\href{http://url/file.txt}{http:\slash{}\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
 5
 
 \href{}{Empty}\footnote{\href{}{}}.
 
-\href{/url/file.txt}{\textbf{URL} and \emph{title}}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{\textbf{URL} and \emph{title}}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
 10
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-{[URL and title]} (\slash url\slash file.txt ``\emph{title}'').
+{[URL and title]} (\slash{}url\slash{}file.txt ``\emph{title}'').
 
 {[URL and title]}
-(\slash url\slash file.txt ``\emph{title}'').
+(\slash{}url\slash{}file.txt ``\emph{title}'').
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
 15
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
-\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash url\slash file.txt}}.
+\href{/url/file.txt}{URL and title}\footnote{\href{/url/file.txt}{\slash{}url\slash{}file.txt}}.
 
 \input{mmd6-article-footer}
 \end{document}

--- a/tests/MMD6Tests/Integrated.tex
+++ b/tests/MMD6Tests/Integrated.tex
@@ -69,7 +69,7 @@ Cite.~\citep{foo}
 \part{Links and Images}
 \label{linksandimages}
 
-\href{http://foo.net/}{link}\footnote{\href{http://foo.net/}{http:\slash \slash foo.net\slash }} and \href{http://bar.net}{link}\footnote{\href{http://bar.net}{http:\slash \slash bar.net}}
+\href{http://foo.net/}{link}\footnote{\href{http://foo.net/}{http:\slash{}\slash{}foo.net\slash{}}} and \href{http://bar.net}{link}\footnote{\href{http://bar.net}{http:\slash{}\slash{}bar.net}}
 
 \begin{figure}[htbp]
 \centering

--- a/tests/MMD6Tests/Link Attributes.tex
+++ b/tests/MMD6Tests/Link Attributes.tex
@@ -4,11 +4,11 @@
 
 foo \includegraphics[width=40pt,height=400pt]{http://foo.bar/}
 
-foo \href{http://foo.bar/1}{link}\footnote{\href{http://foo.bar/1}{http:\slash \slash foo.bar\slash 1}}
+foo \href{http://foo.bar/1}{link}\footnote{\href{http://foo.bar/1}{http:\slash{}\slash{}foo.bar\slash{}1}}
 
-foo \href{http://foo.bar/2}{link2}\footnote{\href{http://foo.bar/2}{http:\slash \slash foo.bar\slash 2}}
+foo \href{http://foo.bar/2}{link2}\footnote{\href{http://foo.bar/2}{http:\slash{}\slash{}foo.bar\slash{}2}}
 
-foo \href{http://foo.bar/3}{link3}\footnote{\href{http://foo.bar/3}{http:\slash \slash foo.bar\slash 3}}
+foo \href{http://foo.bar/3}{link3}\footnote{\href{http://foo.bar/3}{http:\slash{}\slash{}foo.bar\slash{}3}}
 
 \begin{figure}[htbp]
 \centering

--- a/tests/MMD6Tests/Link Variations.tex
+++ b/tests/MMD6Tests/Link Variations.tex
@@ -19,17 +19,17 @@ Link to \autoref{foobar}.
 
 Link to Foo (\autoref{foobar}).
 
-\href{http://example.com/?bar=foo&foo=bar}{\& link}\footnote{\href{http://example.com/?bar=foo&foo=bar}{http:\slash \slash example.com\slash ?bar=foo\&foo=bar}}
+\href{http://example.com/?bar=foo&foo=bar}{\& link}\footnote{\href{http://example.com/?bar=foo&foo=bar}{http:\slash{}\slash{}example.com\slash{}?bar=foo\&foo=bar}}
 
-\href{http://example.com/%25%20link}{`\%' Link}\footnote{\href{http://example.com/%25%20link}{http:\slash \slash example.com\slash \%25\%20link}}
+\href{http://example.com/%25%20link}{`\%' Link}\footnote{\href{http://example.com/%25%20link}{http:\slash{}\slash{}example.com\slash{}\%25\%20link}}
 
-\href{http://example.com/#foo}{`\#' link}\footnote{\href{http://example.com/#foo}{http:\slash \slash example.com\slash \#foo}}
+\href{http://example.com/#foo}{`\#' link}\footnote{\href{http://example.com/#foo}{http:\slash{}\slash{}example.com\slash{}\#foo}}
 
 10
 
-\href{http://example.com/_foo}{\_ link}\footnote{\href{http://example.com/_foo}{http:\slash \slash example.com\slash \_foo}}
+\href{http://example.com/_foo}{\_ link}\footnote{\href{http://example.com/_foo}{http:\slash{}\slash{}example.com\slash{}\_foo}}
 
-\href{http://example.com/~foo}{\ensuremath{\sim} link}\footnote{\href{http://example.com/~foo}{http:\slash \slash example.com\slash \ensuremath{\sim}foo}}
+\href{http://example.com/~foo}{\ensuremath{\sim} link}\footnote{\href{http://example.com/~foo}{http:\slash{}\slash{}example.com\slash{}\ensuremath{\sim}foo}}
 
 \input{mmd6-article-footer}
 \end{document}

--- a/tests/MMD6Tests/Markdown Syntax.tex
+++ b/tests/MMD6Tests/Markdown Syntax.tex
@@ -55,7 +55,7 @@
 \end{itemize}
 
 \textbf{Note:} This document is itself written using Markdown; you
-can \href{/projects/markdown/syntax.text}{see the source for it by adding `.text' to the URL}\footnote{\href{/projects/markdown/syntax.text}{\slash projects\slash markdown\slash syntax.text}}.
+can \href{/projects/markdown/syntax.text}{see the source for it by adding `.text' to the URL}\footnote{\href{/projects/markdown/syntax.text}{\slash{}projects\slash{}markdown\slash{}syntax.text}}.
 
 \begin{center}\rule{3in}{0.4pt}\end{center}
 
@@ -65,8 +65,8 @@ Readability, however, is emphasized above all else. A Markdown-formatted
 document should be publishable as-is, as plain text, without looking
 like it's been marked up with tags or formatting instructions. While
 Markdown's syntax has been influenced by several existing text-to-HTML
-filters -- including \href{http://docutils.sourceforge.net/mirror/setext.html}{Setext}\footnote{\href{http://docutils.sourceforge.net/mirror/setext.html}{http:\slash \slash docutils.sourceforge.net\slash mirror\slash setext.html}}, \href{http://www.aaronsw.com/2002/atx/}{atx}\footnote{\href{http://www.aaronsw.com/2002/atx/}{http:\slash \slash www.aaronsw.com\slash 2002\slash atx\slash }}, \href{http://textism.com/tools/textile/}{Textile}\footnote{\href{http://textism.com/tools/textile/}{http:\slash \slash textism.com\slash tools\slash textile\slash }}, \href{http://docutils.sourceforge.net/rst.html}{reStructuredText}\footnote{\href{http://docutils.sourceforge.net/rst.html}{http:\slash \slash docutils.sourceforge.net\slash rst.html}},
-\href{http://www.triptico.com/software/grutatxt.html}{Grutatext}\footnote{\href{http://www.triptico.com/software/grutatxt.html}{http:\slash \slash www.triptico.com\slash software\slash grutatxt.html}}, and \href{http://ettext.taint.org/doc/}{EtText}\footnote{\href{http://ettext.taint.org/doc/}{http:\slash \slash ettext.taint.org\slash doc\slash }} -- the single biggest source of
+filters -- including \href{http://docutils.sourceforge.net/mirror/setext.html}{Setext}\footnote{\href{http://docutils.sourceforge.net/mirror/setext.html}{http:\slash{}\slash{}docutils.sourceforge.net\slash{}mirror\slash{}setext.html}}, \href{http://www.aaronsw.com/2002/atx/}{atx}\footnote{\href{http://www.aaronsw.com/2002/atx/}{http:\slash{}\slash{}www.aaronsw.com\slash{}2002\slash{}atx\slash{}}}, \href{http://textism.com/tools/textile/}{Textile}\footnote{\href{http://textism.com/tools/textile/}{http:\slash{}\slash{}textism.com\slash{}tools\slash{}textile\slash{}}}, \href{http://docutils.sourceforge.net/rst.html}{reStructuredText}\footnote{\href{http://docutils.sourceforge.net/rst.html}{http:\slash{}\slash{}docutils.sourceforge.net\slash{}rst.html}},
+\href{http://www.triptico.com/software/grutatxt.html}{Grutatext}\footnote{\href{http://www.triptico.com/software/grutatxt.html}{http:\slash{}\slash{}www.triptico.com\slash{}software\slash{}grutatxt.html}}, and \href{http://ettext.taint.org/doc/}{EtText}\footnote{\href{http://ettext.taint.org/doc/}{http:\slash{}\slash{}ettext.taint.org\slash{}doc\slash{}}} -- the single biggest source of
 inspiration for Markdown's syntax is the format of plain text email.
 
 To this end, Markdown's syntax is comprised entirely of punctuation
@@ -204,17 +204,17 @@ The implication of the ``one or more consecutive lines of text'' rule is
 that Markdown supports ``hard-wrapped'' text paragraphs. This differs
 significantly from most other text-to-HTML formatters (including Movable
 Type's ``Convert Line Breaks'' option) which translate every line break
-character in a paragraph into a \texttt{<br \slash >} tag.
+character in a paragraph into a \texttt{<br \slash{}>} tag.
 
-When you \emph{do} want to insert a \texttt{<br \slash >} break tag using Markdown, you
+When you \emph{do} want to insert a \texttt{<br \slash{}>} break tag using Markdown, you
 end a line with two or more spaces, then type return.
 
-Yes, this takes a tad more effort to create a \texttt{<br \slash >}, but a simplistic
-``every line break is a \texttt{<br \slash >}'' rule wouldn't work for Markdown.
+Yes, this takes a tad more effort to create a \texttt{<br \slash{}>}, but a simplistic
+``every line break is a \texttt{<br \slash{}>}'' rule wouldn't work for Markdown.
 Markdown's email-style blockquoting (\autoref{blockquote}) and multi-paragraph list items (\autoref{list})
 work best -- and look better -- when you format them with hard breaks.
 
-Markdown supports two styles of headers, \href{http://docutils.sourceforge.net/mirror/setext.html}{Setext}\footnote{\href{http://docutils.sourceforge.net/mirror/setext.html}{http:\slash \slash docutils.sourceforge.net\slash mirror\slash setext.html}} and \href{http://www.aaronsw.com/2002/atx/}{atx}\footnote{\href{http://www.aaronsw.com/2002/atx/}{http:\slash \slash www.aaronsw.com\slash 2002\slash atx\slash }}.
+Markdown supports two styles of headers, \href{http://docutils.sourceforge.net/mirror/setext.html}{Setext}\footnote{\href{http://docutils.sourceforge.net/mirror/setext.html}{http:\slash{}\slash{}docutils.sourceforge.net\slash{}mirror\slash{}setext.html}} and \href{http://www.aaronsw.com/2002/atx/}{atx}\footnote{\href{http://www.aaronsw.com/2002/atx/}{http:\slash{}\slash{}www.aaronsw.com\slash{}2002\slash{}atx\slash{}}}.
 
 Setext-style headers are ``underlined'' using equal signs (for first-level
 headers) and dashes (for second-level headers). For example:
@@ -575,7 +575,7 @@ Regular Markdown syntax is not processed within code blocks. E.g.,
 asterisks are just literal asterisks within a code block. This means
 it's also easy to use Markdown to write about Markdown's own syntax.
 
-You can produce a horizontal rule tag (\texttt{<hr \slash >}) by placing three or
+You can produce a horizontal rule tag (\texttt{<hr \slash{}>}) by placing three or
 more hyphens, asterisks, or underscores on a line by themselves. If you
 wish, you may use spaces between the hyphens or asterisks. Each of the
 following lines will produce a horizontal rule:

--- a/tests/MMD6Tests/Reference Links.tex
+++ b/tests/MMD6Tests/Reference Links.tex
@@ -2,56 +2,56 @@
 \def\mytitle{Reference Links}
 \input{mmd6-article-begin}
 
-\href{http://test.1/file.txt}{\emph{foo}}\footnote{\href{http://test.1/file.txt}{http:\slash \slash test.1\slash file.txt}}.
+\href{http://test.1/file.txt}{\emph{foo}}\footnote{\href{http://test.1/file.txt}{http:\slash{}\slash{}test.1\slash{}file.txt}}.
 
-\href{http://test.1/file.txt}{\emph{foo}}\footnote{\href{http://test.1/file.txt}{http:\slash \slash test.1\slash file.txt}}.
+\href{http://test.1/file.txt}{\emph{foo}}\footnote{\href{http://test.1/file.txt}{http:\slash{}\slash{}test.1\slash{}file.txt}}.
 
-\href{http://test.3/file.txt}{\emph{foo}}\footnote{\href{http://test.3/file.txt}{http:\slash \slash test.3\slash file.txt}}.
+\href{http://test.3/file.txt}{\emph{foo}}\footnote{\href{http://test.3/file.txt}{http:\slash{}\slash{}test.3\slash{}file.txt}}.
 
-\href{http://test.4/}{\emph{foo}}\footnote{\href{http://test.4/}{http:\slash \slash test.4\slash }}.
+\href{http://test.4/}{\emph{foo}}\footnote{\href{http://test.4/}{http:\slash{}\slash{}test.4\slash{}}}.
 
-\href{http://test.4/}{\emph{foo}}\footnote{\href{http://test.4/}{http:\slash \slash test.4\slash }}.
+\href{http://test.4/}{\emph{foo}}\footnote{\href{http://test.4/}{http:\slash{}\slash{}test.4\slash{}}}.
 
 5
 
-\href{http://test.6/}{\emph{foo}}\footnote{\href{http://test.6/}{http:\slash \slash test.6\slash }}.
+\href{http://test.6/}{\emph{foo}}\footnote{\href{http://test.6/}{http:\slash{}\slash{}test.6\slash{}}}.
 
-\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash \slash test.0\slash }}.
+\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash{}\slash{}test.0\slash{}}}.
 
-\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash \slash test.0\slash }}.
+\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash{}\slash{}test.0\slash{}}}.
 
-\href{http://test.1/file.txt}{\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash \slash test.0\slash }}}\footnote{\href{http://test.1/file.txt}{http:\slash \slash test.1\slash file.txt}}
+\href{http://test.1/file.txt}{\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash{}\slash{}test.0\slash{}}}}\footnote{\href{http://test.1/file.txt}{http:\slash{}\slash{}test.1\slash{}file.txt}}
 
-\href{http://test.0/}{\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash \slash test.0\slash }}}\footnote{\href{http://test.0/}{http:\slash \slash test.0\slash }}
+\href{http://test.0/}{\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash{}\slash{}test.0\slash{}}}}\footnote{\href{http://test.0/}{http:\slash{}\slash{}test.0\slash{}}}
 
 10
 
-\href{http://test.3/file.txt}{\href{http://test.1/file.txt}{foo}\footnote{\href{http://test.1/file.txt}{http:\slash \slash test.1\slash file.txt}}}\footnote{\href{http://test.3/file.txt}{http:\slash \slash test.3\slash file.txt}}
+\href{http://test.3/file.txt}{\href{http://test.1/file.txt}{foo}\footnote{\href{http://test.1/file.txt}{http:\slash{}\slash{}test.1\slash{}file.txt}}}\footnote{\href{http://test.3/file.txt}{http:\slash{}\slash{}test.3\slash{}file.txt}}
 
-\href{http://test.1/file.txt}{foo}\footnote{\href{http://test.1/file.txt}{http:\slash \slash test.1\slash file.txt}}
+\href{http://test.1/file.txt}{foo}\footnote{\href{http://test.1/file.txt}{http:\slash{}\slash{}test.1\slash{}file.txt}}
 
-\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash \slash test.0\slash }} \href{http://test.1/file.txt}{bar}\footnote{\href{http://test.1/file.txt}{http:\slash \slash test.1\slash file.txt}}
+\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash{}\slash{}test.0\slash{}}} \href{http://test.1/file.txt}{bar}\footnote{\href{http://test.1/file.txt}{http:\slash{}\slash{}test.1\slash{}file.txt}}
 
-\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash \slash test.0\slash }}
-\href{http://test.1/file.txt}{bar}\footnote{\href{http://test.1/file.txt}{http:\slash \slash test.1\slash file.txt}}
+\href{http://test.0/}{foo}\footnote{\href{http://test.0/}{http:\slash{}\slash{}test.0\slash{}}}
+\href{http://test.1/file.txt}{bar}\footnote{\href{http://test.1/file.txt}{http:\slash{}\slash{}test.1\slash{}file.txt}}
 
-\href{http://daringfireball.net/projects/markdown/}{Markdown}\footnote{\href{http://daringfireball.net/projects/markdown/}{http:\slash \slash daringfireball.net\slash projects\slash markdown\slash }}
+\href{http://daringfireball.net/projects/markdown/}{Markdown}\footnote{\href{http://daringfireball.net/projects/markdown/}{http:\slash{}\slash{}daringfireball.net\slash{}projects\slash{}markdown\slash{}}}
 
 15
 
-\href{http://test.7/}{angle1}\footnote{\href{http://test.7/}{http:\slash \slash test.7\slash }}
+\href{http://test.7/}{angle1}\footnote{\href{http://test.7/}{http:\slash{}\slash{}test.7\slash{}}}
 
-\href{http://test.8/}{angle2}\footnote{\href{http://test.8/}{http:\slash \slash test.8\slash }}
+\href{http://test.8/}{angle2}\footnote{\href{http://test.8/}{http:\slash{}\slash{}test.8\slash{}}}
 
-\href{http://test.9/}{angle3}\footnote{\href{http://test.9/}{http:\slash \slash test.9\slash }}
+\href{http://test.9/}{angle3}\footnote{\href{http://test.9/}{http:\slash{}\slash{}test.9\slash{}}}
 
-\href{http://test.10/}{angle4}\footnote{\href{http://test.10/}{http:\slash \slash test.10\slash }}
+\href{http://test.10/}{angle4}\footnote{\href{http://test.10/}{http:\slash{}\slash{}test.10\slash{}}}
 
-\href{http://test.11/}{angle5}\footnote{\href{http://test.11/}{http:\slash \slash test.11\slash }}
+\href{http://test.11/}{angle5}\footnote{\href{http://test.11/}{http:\slash{}\slash{}test.11\slash{}}}
 
 20
 
-\href{http://test.12/}{angle6}\footnote{\href{http://test.12/}{http:\slash \slash test.12\slash }}
+\href{http://test.12/}{angle6}\footnote{\href{http://test.12/}{http:\slash{}\slash{}test.12\slash{}}}
 
 \input{mmd6-article-footer}
 \end{document}

--- a/tests/MMD6Tests/Superscript.tex
+++ b/tests/MMD6Tests/Superscript.tex
@@ -20,7 +20,7 @@ x\textsubscript{xyz}.
 
 z\textsubscript{z.}
 
-\ensuremath{\sim}\slash Library\slash MultiMarkdown
+\ensuremath{\sim}\slash{}Library\slash{}MultiMarkdown
 
 \textsuperscript{test}
 

--- a/tests/MMD6Tests/Transclusion.tex
+++ b/tests/MMD6Tests/Transclusion.tex
@@ -21,9 +21,9 @@ This is a file with no metadata.
 This is a file with no metadata.
 \end{verbatim}
 
-\{\{transclusion\slash bat.*\}\}
+\{\{transclusion\slash{}bat.*\}\}
 
-This text is included in \texttt{transclusion\slash baz.txt}.
+This text is included in \texttt{transclusion\slash{}baz.txt}.
 
 This should pull in \texttt{bar.txt}, \emph{if} run from the parent directory, since it
 does \emph{not} override the \texttt{transclude base} metadata.
@@ -43,9 +43,9 @@ This is a file with no metadata.
 This is a file with no metadata.
 \end{verbatim}
 
-This text is included in \texttt{transclusion\slash baz2.txt}.
+This text is included in \texttt{transclusion\slash{}baz2.txt}.
 
-This should pull in \texttt{transclusion\slash bar.txt}, \emph{even if} run from the parent
+This should pull in \texttt{transclusion\slash{}bar.txt}, \emph{even if} run from the parent
 directory, since it overrides the \texttt{transclude base} metadata.
 
 This text is included in \texttt{transclusion\textbackslash{}bar.txt}.

--- a/tests/Memoir/Integ.tex
+++ b/tests/Memoir/Integ.tex
@@ -69,7 +69,7 @@ Cite.~\citep{foo}
 \part{Links and Images }
 \label{linksandimages}
 
-\href{http://foo.net/}{link}\footnote{\href{http://foo.net/}{http:\slash \slash foo.net\slash }} and \href{http://bar.net}{link}\footnote{\href{http://bar.net}{http:\slash \slash bar.net}}
+\href{http://foo.net/}{link}\footnote{\href{http://foo.net/}{http:\slash{}\slash{}foo.net\slash{}}} and \href{http://bar.net}{link}\footnote{\href{http://bar.net}{http:\slash{}\slash{}bar.net}}
 
 \begin{figure}[htbp]
 \centering

--- a/tests/Memoir/Integrated.tex
+++ b/tests/Memoir/Integrated.tex
@@ -72,7 +72,7 @@ Cite.~\citep{foo}
 \part{Links and Images}
 \label{linksandimages}
 
-\href{http://foo.net/}{link}\footnote{\href{http://foo.net/}{http:\slash \slash foo.net\slash }} and \href{http://bar.net}{link}\footnote{\href{http://bar.net}{http:\slash \slash bar.net}}
+\href{http://foo.net/}{link}\footnote{\href{http://foo.net/}{http:\slash{}\slash{}foo.net\slash{}}} and \href{http://bar.net}{link}\footnote{\href{http://bar.net}{http:\slash{}\slash{}bar.net}}
 
 \begin{figure}[htbp]
 \centering


### PR DESCRIPTION
In a text fragment "abc / def" where the space after the slash is intended the latex export would write a `\slash `, i.e. with a trailing space (as a separator). LateX though will collapse and ignore all spaces after a macro, and thus after a lateX run the resulting snippet would look like "abc /def", which is clearly not what is wanted. Letting write the export `\slash{}` gives what's needed.  This is by the way also inline with exports like how `\` are exported: `\textbackslash{}`.